### PR TITLE
Potential fix for code scanning alert no. 21: Information exposure through a stack trace

### DIFF
--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -14,7 +14,8 @@ router.post('/register', async (req, res) => {
         const token = jwt.sign({ _id: user._id }, process.env.JWT_SECRET, { expiresIn: '1h' });
         res.status(201).send({ user, token });
     } catch (error) {
-        res.status(400).send(error);
+        console.error("Error during registration:", error);
+        res.status(400).send({ message: "An error occurred. Please try again later." });
     }
 });
 
@@ -26,7 +27,8 @@ router.post('/login', async (req, res) => {
         const token = jwt.sign({ _id: user._id }, process.env.JWT_SECRET, { expiresIn: '1h' });
         res.send({ user, token });
     } catch (error) {
-        res.status(400).send(error);
+        console.error("Error during login:", error);
+        res.status(400).send({ message: "An error occurred. Please try again later." });
     }
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/temichelle13/StudyPlanner/security/code-scanning/21](https://github.com/temichelle13/StudyPlanner/security/code-scanning/21)

To fix the issue, we need to ensure that sensitive information, such as stack traces, is not exposed to the client. Instead, we should log the error details on the server for debugging purposes and send a generic error message to the client. This can be achieved by replacing the `res.status(400).send(error)` statement with a logging mechanism for the error and a generic response message for the client.

Steps to implement the fix:
1. Replace the `res.status(400).send(error)` statement with a logging mechanism (e.g., `console.error`) to log the error details on the server.
2. Send a generic error message to the client, such as `"An error occurred. Please try again later."`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
