### PR TITLE
Fix README installation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ Installation Guidelines:
 ```bash
 git clone https://github.com/yourusername/StudyPlanner.git
 cd StudyPlanner
-nmp install
+npm install
 ```


### PR DESCRIPTION
## Summary
- correct a typo in the README installation instructions

## Testing
- `grep -n "npm install" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_6847db9d32ec832a9f353188dcfcdcf2