### PR TITLE
Add Task model validation test and clean up

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
     coverageDirectory: 'coverage',
     testPathIgnorePatterns: ['/node_modules/'],
     coveragePathIgnorePatterns: ['/node_modules/', '/tests/'],
+    roots: ['<rootDir>', '<rootDir>/test'],
     coverageThreshold: {
       global: {
         branches: 70,
@@ -13,5 +14,4 @@ module.exports = {
         statements: 80
       }
     }
-  };
-  
+};

--- a/test/taskModel.test.js
+++ b/test/taskModel.test.js
@@ -1,0 +1,18 @@
+const mongoose = require('mongoose');
+const Task = require('../models/task');
+
+describe('Task Model Validation', () => {
+  it('should fail validation for past dueDate', async () => {
+    const pastDate = new Date(Date.now() - 24 * 60 * 60 * 1000); // yesterday
+    const task = new Task({ title: 'Past Due Task', dueDate: pastDate });
+
+    try {
+      await task.validate();
+      // If validate does not throw, force fail
+      throw new Error('Validation should have failed for past dueDate');
+    } catch (err) {
+      expect(err).toBeInstanceOf(mongoose.Error.ValidationError);
+      expect(err.errors.dueDate).toBeDefined();
+    }
+  });
+});

--- a/test_dir/test_file.txt
+++ b/test_dir/test_file.txt
@@ -1,1 +1,0 @@
-Testing file creation to diagnose error cause.


### PR DESCRIPTION
## Summary
- remove old test file
- ensure Jest uses `test` directory
- add unit test verifying Task schema rejects past due dates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847db999720832a84b1770922e0db84