### PR TITLE
Add guidance-focused project plan updates

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -1,0 +1,130 @@
+# StudyPlanner Project Plan
+
+## Guiding Principles
+- Center the experience around adult and remote learners who often juggle work, family, and education commitments.
+- Blend scheduling utilities with actionable guidance on financial aid, scholarship discovery, and recognition of prior learning.
+- Validate every major guidance workflow with real learners and partner organizations before scaling the experience.
+
+## Sprint Overview
+| Sprint | Theme | Key Objectives | Primary Deliverables |
+| --- | --- | --- | --- |
+| 0 | Discovery Kickoff | Understand adult & remote learner needs and ecosystem | Research brief, initial persona set |
+| 1 | Content Sourcing & Partnerships | Curate credible guidance assets and allies | Resource inventory, partnership outreach tracker |
+| 2 | Guidance Knowledge Base Foundation | Design information architecture and author core workflows | Knowledge base architecture, draft workflow maps |
+| 3 | Knowledge Base Validation & Integration | Implement and validate guidance flows in product backlog | Validated workflow library, integration plan |
+| 4 | UX Flow Prototyping | Prototype guided experiences alongside scheduling | Interactive UX prototypes, content-feedback loops |
+| 5 | End-to-End Testing & Launch Prep | Test guidance experiences and prep for release | Remote usability report, launch readiness checklist |
+| 6 | Launch & Continuous Improvement | Roll out and monitor guidance experiences | Analytics dashboard, iteration backlog |
+
+---
+
+### Sprint 0 – Discovery Kickoff (Weeks 1–2)
+**Goals**
+- Build foundational understanding of adult and remote learner motivations, barriers, and support needs.
+- Document how learners currently navigate financial aid, scholarships, and prior-learning assessments (PLAs).
+
+**Key Tasks**
+- Conduct 10–12 remote-friendly interviews with adult learners (ages 24+) covering time management, funding navigation, and remote study habits.
+- Field a short survey through community college partner lists to quantify pain points for remote learners seeking financial aid and PLA guidance.
+- Map stakeholder ecosystem (workforce boards, employer tuition programs, scholarship foundations) to identify potential allies.
+
+**Deliverables**
+- Discovery research brief synthesizing learner personas, journey pain points, and guidance gaps for remote audiences.
+- Initial persona deck (3–4 personas) emphasizing adult and remote learner contexts.
+- Ecosystem map highlighting potential partnership targets and channels for outreach.
+
+### Sprint 1 – Content Sourcing & Partnership Outreach (Weeks 3–4)
+**Goals**
+- Curate credible guidance assets tailored to adult and remote learners.
+- Initiate partnerships that can enrich guidance content and provide validation touchpoints.
+
+**Key Tasks**
+- Audit federal, state, and institutional financial aid resources; tag those that can be translated into step-by-step workflows for adults studying remotely.
+- Source scholarship databases emphasizing flexible or remote-friendly programs and assess APIs/licensing for integration.
+- Outreach to at least 5 organizations (e.g., community colleges, employer education benefits teams, PLA assessment providers) to explore content co-creation or validation partnerships.
+- Document current institutional PLA policies and credit-transfer practices relevant to adult learners.
+
+**Deliverables**
+- Guidance content inventory spreadsheet with quality scores, licensing notes, and remote-learner applicability tags.
+- Partnership outreach tracker capturing contacts, status, and next steps for each strategic partner.
+- Content gap analysis identifying missing assets for financial aid workflows, scholarship matching, and PLA preparation.
+
+### Sprint 2 – Guidance Knowledge Base Foundation (Weeks 5–6)
+**Goals**
+- Establish the structure, taxonomy, and authoring standards for the guidance knowledge base.
+- Convert priority content into actionable workflows for financial aid, scholarship discovery, and PLAs.
+
+**Key Tasks**
+- Design IA and schema for the knowledge base (topics, personas, prerequisite skills) optimized for adult remote learners.
+- Draft detailed financial aid workflow maps, including FAFSA milestones, employer tuition reimbursement steps, and remote verification requirements.
+- Build initial scholarship matching rulesets (e.g., filters by modality, schedule flexibility, prior credits) using sourced datasets.
+- Outline PLA readiness checklists and assessment prep guides in collaboration with identified partners.
+
+**Deliverables**
+- Knowledge base architecture document (schema diagrams, taxonomy definitions, authoring guidelines).
+- Draft workflow packet covering financial aid processes, scholarship matching decision trees, and PLA readiness guides for validation in Sprint 3.
+- Content governance plan defining update cadence, owner roles, and partner feedback loops.
+
+### Sprint 3 – Knowledge Base Validation & Integration (Weeks 7–8)
+**Goals**
+- Validate guidance workflows with target learners and partners before embedding them in the product backlog.
+- Prioritize technical integration tasks required to surface guidance alongside scheduling features.
+
+**Key Tasks**
+- Conduct moderated walkthrough sessions (6–8 participants) to validate the financial aid and scholarship decision trees created in Sprint 2, capturing comprehension and trust scores.
+- Host partner review workshops (community college advisor, workforce board rep, PLA coordinator) to vet PLA guidance accuracy and remote applicability.
+- Translate validated workflows into structured content within the CMS/knowledge base tool, tagging states for personalization.
+- Collaborate with engineering to define APIs or data models needed to expose guidance modules inside the StudyPlanner app.
+
+**Deliverables**
+- Validated guidance workflow library with sign-off notes for financial aid, scholarship matching, and PLA checklists.
+- Integration requirements document and user stories prioritized in the backlog for subsequent development sprints.
+- Partner feedback summary with commitments for ongoing updates or learner referrals.
+
+### Sprint 4 – UX Flow Prototyping (Weeks 9–10)
+**Goals**
+- Design cohesive UX flows that weave guidance experiences into task scheduling journeys.
+- Prototype interactions that support adult and remote learners in completing guidance workflows.
+
+**Key Tasks**
+- Create mid- to high-fidelity prototypes illustrating how learners discover and follow financial aid workflows, scholarship suggestions, and PLA preparation steps within the planner.
+- Define contextual nudges and notifications tailored to remote learners (e.g., asynchronous support prompts, timezone-aware reminders).
+- Collaborate with content to script in-product copy, decision points, and fallback resources for each guidance flow.
+- Run heuristic reviews with UX and accessibility experts focusing on remote usability (keyboard navigation, low-bandwidth scenarios).
+
+**Deliverables**
+- Prototype deck and clickable Figma flows covering onboarding, financial aid guidance, scholarship matching, and PLA preparation pathways.
+- Interaction specification document detailing states, validations, and content triggers for each guidance experience.
+- Accessibility and heuristic review log with prioritized remediation items feeding Sprint 5.
+
+### Sprint 5 – End-to-End Testing & Launch Prep (Weeks 11–12)
+**Goals**
+- Validate guidance UX flows with real users and ensure technical readiness for launch.
+- Prepare support materials and success metrics tailored to adult and remote learners.
+
+**Key Tasks**
+- Conduct remote usability tests (10 participants) covering end-to-end guidance scenarios, measuring task completion rates, comprehension, and perceived value.
+- Execute cross-browser and device QA on guidance flows, including low-bandwidth simulations and asynchronous notification checks.
+- Coordinate with partner organizations to pilot content updates and gather testimonials or case studies.
+- Finalize knowledge base analytics instrumentation (tracking workflow engagement, drop-offs, and satisfaction surveys).
+
+**Deliverables**
+- Remote usability test report with prioritized improvements for guidance experiences.
+- Launch readiness checklist covering QA sign-offs, content governance, support scripts, and partner commitments.
+- Analytics & success metric dashboard plan for monitoring guidance usage post-launch.
+
+### Sprint 6 – Launch & Continuous Improvement (Weeks 13–14)
+**Goals**
+- Launch guidance-enhanced StudyPlanner experience and monitor adoption among adult and remote learners.
+- Establish an iteration cadence informed by data and partner feedback.
+
+**Key Tasks**
+- Deploy knowledge base content and UX flows to production with staged rollout for partner pilot cohorts.
+- Monitor analytics dashboard and in-app surveys to identify friction in financial aid, scholarship, and PLA flows.
+- Facilitate bi-weekly partner check-ins to review learner outcomes, share insights, and queue new content requests.
+- Groom backlog for future releases (e.g., employer-specific guidance, multilingual support) based on early performance.
+
+**Deliverables**
+- Launch report summarizing key adoption metrics, learner satisfaction, and support incidents within the first month.
+- Continuous improvement backlog prioritized by impact on adult and remote learner success.
+- Partnership engagement scorecard tracking collaboration health and pipeline opportunities.


### PR DESCRIPTION
## Summary
- add a project plan outlining discovery, content sourcing, and partnership work for adult and remote learners
- define guidance knowledge base deliverables for financial aid workflows, scholarship matching, and prior-learning assessments
- schedule UX prototyping and validation activities to weave guidance experiences into the StudyPlanner product

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cafe3a55b0832a8e22113fb3b63e2e